### PR TITLE
Use sidebar navigation on desktop home page

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -37,6 +37,17 @@ p,li,code,pre{font-size:var(--f-b)} small{font-size:var(--f-cap);color:var(--mut
 .bottombar a:active{background:color-mix(in oklab,var(--accent),transparent 85%)}
 @media (max-width:380px){ .bottombar small{font-size:10px} }
 @media (max-width:340px){ .bottombar small{display:none} }
+
+/* Layout + sidebar on desktop */
+.layout{display:block}
+@media (min-width:768px){
+  .layout{display:flex;align-items:flex-start}
+  .layout .drawer{position:sticky;top:0;transform:none;width:260px;border-left:none;border-right:1px solid var(--border);box-shadow:none;height:100vh;padding-bottom:20px}
+  .layout main{flex:1}
+  .wrap{padding-bottom:40px}
+  #closeDrawer{display:none}
+  .bottombar{display:none}
+}
 /* Buttons */
 .btn{appearance:none;border:none;padding:12px 16px;border-radius:var(--r-pill);font-weight:700;cursor:pointer;transition:background var(--dur-hover) var(--ease),transform var(--dur-press) var(--ease),box-shadow var(--dur-hover) var(--ease);white-space:nowrap;touch-action:manipulation}
 .btn:active{transform:translateY(1px)}

--- a/assets/js/core/ui.js
+++ b/assets/js/core/ui.js
@@ -8,6 +8,23 @@ if(openD && drawer && closeD){
   closeD.addEventListener("click", ()=> { drawer.classList.remove("show"); drawer.setAttribute('aria-hidden','true'); untrap && untrap(); });
   document.addEventListener("keydown", e=>{ if(e.key==="Escape") { drawer.classList.remove("show"); drawer.setAttribute('aria-hidden','true'); untrap && untrap(); } });
 }
+
+if(drawer){
+  const mql = window.matchMedia('(min-width: 768px)');
+  const updateDrawer = e => {
+    if(e.matches){
+      drawer.classList.add('show');
+      drawer.setAttribute('aria-hidden','false');
+      drawer.removeAttribute('tabindex');
+    } else {
+      drawer.classList.remove('show');
+      drawer.setAttribute('aria-hidden','true');
+      drawer.setAttribute('tabindex','-1');
+    }
+  };
+  mql.addEventListener('change', updateDrawer);
+  updateDrawer(mql);
+}
 qsa(".themeBtn").forEach(btn=>{
   btn.addEventListener("click", ()=>{
     setTheme(btn.dataset.theme);

--- a/index.html
+++ b/index.html
@@ -46,24 +46,25 @@
           <a class="btn btn-primary" href="effects/add.html"><svg class="icon"><use href="#ic-plus"/></svg> Effetto</a>
         </div>
       </div>
-    </div>
   </div>
-
-  <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
-    <div class="cluster" style="justify-content:space-between">
-      <strong>Menu</strong>
-      <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
-    </div>
-    <nav class="stack" style="margin-top:12px">
-      <a class="btn btn-ghost" href="index.html"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
-      <a class="btn btn-ghost" href="effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Catalogo</a>
-      <a class="btn btn-ghost" href="routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
-      <a class="btn btn-ghost" href="show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
-      <a class="btn btn-ghost" href="practice/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Practice</a>
-      <a class="btn btn-ghost" href="settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
-    </nav>
-  </aside>
-  <main id="contenuto" class="wrap">
+  </div>
+  
+  <div class="layout">
+    <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
+      <div class="cluster" style="justify-content:space-between">
+        <strong>Menu</strong>
+        <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
+      </div>
+      <nav class="stack" style="margin-top:12px">
+        <a class="btn btn-ghost" href="index.html"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
+        <a class="btn btn-ghost" href="effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Catalogo</a>
+        <a class="btn btn-ghost" href="routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
+        <a class="btn btn-ghost" href="show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
+        <a class="btn btn-ghost" href="practice/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Practice</a>
+        <a class="btn btn-ghost" href="settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
+      </nav>
+    </aside>
+    <main id="contenuto" class="wrap">
     
 <section class="stack">
   <header class="surface stack">
@@ -155,7 +156,8 @@
 </section>
 
   </main>
-  
+  </div>
+
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
     <a href="index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
     <a href="effects/index.html" aria-label="Catalogo"><svg class="icon"><use href="#ic-book"/></svg><small>Catalogo</small></a>


### PR DESCRIPTION
## Summary
- Show navigation drawer as permanent sidebar on desktop and retain mobile bottom menu
- Update layout styles and responsive script to switch between sidebar and mobile drawer

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a371259e188322803a3c2455267618