### PR TITLE
refactor: improve layout and icons

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -147,7 +147,7 @@ mark{background:color-mix(in oklab,var(--accent),transparent 70%);color:inherit;
 .clamp-2{display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
 .clamp-3{display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden}
 .hidden{display:none!important}
-.icon{width:22px;height:22px}
+.icon{width:24px;height:24px;flex-shrink:0}
 img, svg, video{max-width:100%;height:auto;display:block}
 /* Print */
 @media print{.topbar,.bottombar,.drawer{display:none!important};body{color:#111;background:#fff}}

--- a/effects/add.html
+++ b/effects/add.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="../assets/css/base.css">
 </head>
 <body>
-  <a href="#contenuto" style="position:absolute;left:-9999px;top:auto;">Salta al contenuto</a>
+  <a href="#contenuto" class="skip-link">Salta al contenuto</a>
   <!-- SVG SPRITE -->
 <svg width="0" height="0" style="position:absolute" aria-hidden="true">
   <symbol id="ic-bars" viewBox="0 0 24 24"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
@@ -21,6 +21,7 @@
   <symbol id="ic-book" viewBox="0 0 24 24"><path d="M4 4h12a3 3 0 0 1 3 3v13H7a3 3 0 0 1-3-3V4z" fill="none" stroke="currentColor" stroke-width="2"/></symbol>
   <symbol id="ic-list" viewBox="0 0 24 24"><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
   <symbol id="ic-theatre" viewBox="0 0 24 24"><path d="M9 3c3 0 6 2 6 5v7c0 3-3 5-6 5S3 18 3 15V8c0-3 3-5 6-5zm12 2c-2 0-4 1-5 3v7c1 2 3 3 5 3s4-1 4-3V8c0-2-2-3-4-3z" fill="none" stroke="currentColor" stroke-width="2"/></symbol>
+  <symbol id="ic-practice" viewBox="0 0 24 24"><path d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
   <symbol id="ic-gear" viewBox="0 0 24 24"><path d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm7.4-3a7.4 7.4 0 0 0 0-0l2.1-1.2-1.5-2.6-2.4.6a7.4 7.4 0 0 0-1.6-.9l-.4-2.5h-3l-.4 2.5a7.4 7.4 0 0 0 1.6.9l-2.4.6-1.5 2.6 2.1 1.2a7.4 7.4 0 0 0 0 0l-2.1 1.2 1.5 2.6 2.4-.6a7.4 7.4 0 0 0 1.6.9l.4 2.5h3l.4-2.5a7.4 7.4 0 0 0 1.6-.9l2.4.6 1.5-2.6-2.1-1.2z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
   <symbol id="ic-plus" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
   <symbol id="ic-chevron-right" viewBox="0 0 24 24"><path d="M9 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
@@ -36,10 +37,10 @@
         <span class="wordmark">Midnight <strong style="color:var(--accent)">Spell</strong> — Aggiungi Effetto</span>
       </div>
       <div class="nav-actions">
-        <div class="cluster" role="group" aria-label="Tema">
-          <button class="btn btn-secondary themeBtn" data-theme="dark" aria-pressed="true">Dark</button>
-          <button class="btn btn-secondary themeBtn" data-theme="light" aria-pressed="false">Light</button>
-          <button class="btn btn-secondary themeBtn" data-theme="hc" aria-pressed="false">HC</button>
+        <div class="theme-selector" role="group" aria-label="Tema">
+          <button class="themeBtn" data-theme="dark" aria-pressed="true" aria-label="Tema scuro"></button>
+          <button class="themeBtn" data-theme="light" aria-pressed="false" aria-label="Tema chiaro"></button>
+          <button class="themeBtn" data-theme="hc" aria-pressed="false" aria-label="Tema alto contrasto"></button>
         </div>
         <div class="cluster" role="search">
           <input id="globalSearch" class="input" style="min-width:220px" placeholder="Cerca effetti… ( / )" aria-label="Cerca" />
@@ -59,7 +60,7 @@
       <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Catalogo</a>
       <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
       <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
-      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Practice</a>
+      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
       <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
     </nav>
   </aside>
@@ -86,7 +87,7 @@
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
     <a href="../index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
-    <a href="../effects/index.html" aria-label="Catalogo"><svg class="icon"><use href="#ic-book"/></svg><small>Catalogo</small></a>
+    <a href="../effects/index.html" aria-label="Catalogo" aria-current="page"><svg class="icon"><use href="#ic-book"/></svg><small>Catalogo</small></a>
     <a href="../routine/index.html" aria-label="Routine"><svg class="icon"><use href="#ic-list"/></svg><small>Routine</small></a>
     <a href="../show/index.html" aria-label="Show"><svg class="icon"><use href="#ic-theatre"/></svg><small>Show</small></a>
     <a href="../settings/index.html" aria-label="Impostazioni"><svg class="icon"><use href="#ic-gear"/></svg><small>Impost.</small></a>

--- a/effects/details.html
+++ b/effects/details.html
@@ -21,6 +21,7 @@
   <symbol id="ic-book" viewBox="0 0 24 24"><path d="M4 4h12a3 3 0 0 1 3 3v13H7a3 3 0 0 1-3-3V4z" fill="none" stroke="currentColor" stroke-width="2"/></symbol>
   <symbol id="ic-list" viewBox="0 0 24 24"><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
   <symbol id="ic-theatre" viewBox="0 0 24 24"><path d="M9 3c3 0 6 2 6 5v7c0 3-3 5-6 5S3 18 3 15V8c0-3 3-5 6-5zm12 2c-2 0-4 1-5 3v7c1 2 3 3 5 3s4-1 4-3V8c0-2-2-3-4-3z" fill="none" stroke="currentColor" stroke-width="2"/></symbol>
+  <symbol id="ic-practice" viewBox="0 0 24 24"><path d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
   <symbol id="ic-gear" viewBox="0 0 24 24"><path d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm7.4-3a7.4 7.4 0 0 0 0-0l2.1-1.2-1.5-2.6-2.4.6a7.4 7.4 0 0 0-1.6-.9l-.4-2.5h-3l-.4 2.5a7.4 7.4 0 0 0 1.6.9l-2.4.6-1.5 2.6 2.1 1.2a7.4 7.4 0 0 0 0 0l-2.1 1.2 1.5 2.6 2.4-.6a7.4 7.4 0 0 0 1.6.9l.4 2.5h3l.4-2.5a7.4 7.4 0 0 0 1.6-.9l2.4.6 1.5-2.6-2.1-1.2z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
   <symbol id="ic-plus" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
   <symbol id="ic-chevron-right" viewBox="0 0 24 24"><path d="M9 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
@@ -59,7 +60,7 @@
       <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Catalogo</a>
       <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
       <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
-      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Practice</a>
+      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
       <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
     </nav>
   </aside>
@@ -139,7 +140,7 @@
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
     <a href="../index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
-    <a href="../effects/index.html" aria-label="Catalogo"><svg class="icon"><use href="#ic-book"/></svg><small>Catalogo</small></a>
+    <a href="../effects/index.html" aria-label="Catalogo" aria-current="page"><svg class="icon"><use href="#ic-book"/></svg><small>Catalogo</small></a>
     <a href="../routine/index.html" aria-label="Routine"><svg class="icon"><use href="#ic-list"/></svg><small>Routine</small></a>
     <a href="../show/index.html" aria-label="Show"><svg class="icon"><use href="#ic-theatre"/></svg><small>Show</small></a>
     <a href="../settings/index.html" aria-label="Impostazioni"><svg class="icon"><use href="#ic-gear"/></svg><small>Impost.</small></a>

--- a/effects/index.html
+++ b/effects/index.html
@@ -21,6 +21,7 @@
   <symbol id="ic-book" viewBox="0 0 24 24"><path d="M4 4h12a3 3 0 0 1 3 3v13H7a3 3 0 0 1-3-3V4z" fill="none" stroke="currentColor" stroke-width="2"/></symbol>
   <symbol id="ic-list" viewBox="0 0 24 24"><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
   <symbol id="ic-theatre" viewBox="0 0 24 24"><path d="M9 3c3 0 6 2 6 5v7c0 3-3 5-6 5S3 18 3 15V8c0-3 3-5 6-5zm12 2c-2 0-4 1-5 3v7c1 2 3 3 5 3s4-1 4-3V8c0-2-2-3-4-3z" fill="none" stroke="currentColor" stroke-width="2"/></symbol>
+  <symbol id="ic-practice" viewBox="0 0 24 24"><path d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
   <symbol id="ic-gear" viewBox="0 0 24 24"><path d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm7.4-3a7.4 7.4 0 0 0 0-0l2.1-1.2-1.5-2.6-2.4.6a7.4 7.4 0 0 0-1.6-.9l-.4-2.5h-3l-.4 2.5a7.4 7.4 0 0 0 1.6.9l-2.4.6-1.5 2.6 2.1 1.2a7.4 7.4 0 0 0 0 0l-2.1 1.2 1.5 2.6 2.4-.6a7.4 7.4 0 0 0 1.6.9l.4 2.5h3l.4-2.5a7.4 7.4 0 0 0 1.6-.9l2.4.6 1.5-2.6-2.1-1.2z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
   <symbol id="ic-plus" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
   <symbol id="ic-chevron-right" viewBox="0 0 24 24"><path d="M9 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
@@ -36,10 +37,10 @@
         <span class="wordmark">Midnight <strong style="color:var(--accent)">Spell</strong> — Catalogo</span>
       </div>
       <div class="nav-actions">
-        <div class="cluster" role="group" aria-label="Tema">
-          <button class="btn btn-secondary themeBtn" data-theme="dark" aria-pressed="true">Dark</button>
-          <button class="btn btn-secondary themeBtn" data-theme="light" aria-pressed="false">Light</button>
-          <button class="btn btn-secondary themeBtn" data-theme="hc" aria-pressed="false">HC</button>
+        <div class="theme-selector" role="group" aria-label="Tema">
+          <button class="themeBtn" data-theme="dark" aria-pressed="true" aria-label="Tema scuro"></button>
+          <button class="themeBtn" data-theme="light" aria-pressed="false" aria-label="Tema chiaro"></button>
+          <button class="themeBtn" data-theme="hc" aria-pressed="false" aria-label="Tema alto contrasto"></button>
         </div>
         <div class="cluster" role="search">
           <input id="globalSearch" class="input" style="min-width:220px" placeholder="Cerca effetti… ( / )" aria-label="Cerca" />
@@ -59,7 +60,7 @@
       <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Catalogo</a>
       <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
       <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
-      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Practice</a>
+      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
       <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
     </nav>
   </aside>
@@ -123,7 +124,7 @@
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
     <a href="../index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
-    <a href="../effects/index.html" aria-label="Catalogo"><svg class="icon"><use href="#ic-book"/></svg><small>Catalogo</small></a>
+    <a href="../effects/index.html" aria-label="Catalogo" aria-current="page"><svg class="icon"><use href="#ic-book"/></svg><small>Catalogo</small></a>
     <a href="../routine/index.html" aria-label="Routine"><svg class="icon"><use href="#ic-list"/></svg><small>Routine</small></a>
     <a href="../show/index.html" aria-label="Show"><svg class="icon"><use href="#ic-theatre"/></svg><small>Show</small></a>
     <a href="../settings/index.html" aria-label="Impostazioni"><svg class="icon"><use href="#ic-gear"/></svg><small>Impost.</small></a>

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
   <symbol id="ic-book" viewBox="0 0 24 24"><path d="M4 4h12a3 3 0 0 1 3 3v13H7a3 3 0 0 1-3-3V4z" fill="none" stroke="currentColor" stroke-width="2"/></symbol>
   <symbol id="ic-list" viewBox="0 0 24 24"><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
   <symbol id="ic-theatre" viewBox="0 0 24 24"><path d="M9 3c3 0 6 2 6 5v7c0 3-3 5-6 5S3 18 3 15V8c0-3 3-5 6-5zm12 2c-2 0-4 1-5 3v7c1 2 3 3 5 3s4-1 4-3V8c0-2-2-3-4-3z" fill="none" stroke="currentColor" stroke-width="2"/></symbol>
+  <symbol id="ic-practice" viewBox="0 0 24 24"><path d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
   <symbol id="ic-gear" viewBox="0 0 24 24"><path d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm7.4-3a7.4 7.4 0 0 0 0-0l2.1-1.2-1.5-2.6-2.4.6a7.4 7.4 0 0 0-1.6-.9l-.4-2.5h-3l-.4 2.5a7.4 7.4 0 0 0 1.6.9l-2.4.6-1.5 2.6 2.1 1.2a7.4 7.4 0 0 0 0 0l-2.1 1.2 1.5 2.6 2.4-.6a7.4 7.4 0 0 0 1.6.9l.4 2.5h3l.4-2.5a7.4 7.4 0 0 0 1.6-.9l2.4.6 1.5-2.6-2.1-1.2z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
   <symbol id="ic-plus" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
   <symbol id="ic-chevron-right" viewBox="0 0 24 24"><path d="M9 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
@@ -60,7 +61,7 @@
         <a class="btn btn-ghost" href="effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Catalogo</a>
         <a class="btn btn-ghost" href="routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
         <a class="btn btn-ghost" href="show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
-        <a class="btn btn-ghost" href="practice/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Practice</a>
+        <a class="btn btn-ghost" href="practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
         <a class="btn btn-ghost" href="settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
       </nav>
     </aside>
@@ -159,7 +160,7 @@
   </div>
 
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
-    <a href="index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
+    <a href="index.html" aria-label="Home" aria-current="page"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
     <a href="effects/index.html" aria-label="Catalogo"><svg class="icon"><use href="#ic-book"/></svg><small>Catalogo</small></a>
     <a href="routine/index.html" aria-label="Routine"><svg class="icon"><use href="#ic-list"/></svg><small>Routine</small></a>
     <a href="show/index.html" aria-label="Show"><svg class="icon"><use href="#ic-theatre"/></svg><small>Show</small></a>

--- a/practice/index.html
+++ b/practice/index.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="../assets/css/base.css">
 </head>
 <body>
-  <a href="#contenuto" style="position:absolute;left:-9999px;top:auto;">Salta al contenuto</a>
+  <a href="#contenuto" class="skip-link">Salta al contenuto</a>
   <!-- SVG SPRITE -->
 <svg width="0" height="0" style="position:absolute" aria-hidden="true">
   <symbol id="ic-bars" viewBox="0 0 24 24"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
@@ -21,6 +21,7 @@
   <symbol id="ic-book" viewBox="0 0 24 24"><path d="M4 4h12a3 3 0 0 1 3 3v13H7a3 3 0 0 1-3-3V4z" fill="none" stroke="currentColor" stroke-width="2"/></symbol>
   <symbol id="ic-list" viewBox="0 0 24 24"><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
   <symbol id="ic-theatre" viewBox="0 0 24 24"><path d="M9 3c3 0 6 2 6 5v7c0 3-3 5-6 5S3 18 3 15V8c0-3 3-5 6-5zm12 2c-2 0-4 1-5 3v7c1 2 3 3 5 3s4-1 4-3V8c0-2-2-3-4-3z" fill="none" stroke="currentColor" stroke-width="2"/></symbol>
+  <symbol id="ic-practice" viewBox="0 0 24 24"><path d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
   <symbol id="ic-gear" viewBox="0 0 24 24"><path d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm7.4-3a7.4 7.4 0 0 0 0-0l2.1-1.2-1.5-2.6-2.4.6a7.4 7.4 0 0 0-1.6-.9l-.4-2.5h-3l-.4 2.5a7.4 7.4 0 0 0 1.6.9l-2.4.6-1.5 2.6 2.1 1.2a7.4 7.4 0 0 0 0 0l-2.1 1.2 1.5 2.6 2.4-.6a7.4 7.4 0 0 0 1.6.9l.4 2.5h3l.4-2.5a7.4 7.4 0 0 0 1.6-.9l2.4.6 1.5-2.6-2.1-1.2z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
   <symbol id="ic-plus" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
   <symbol id="ic-chevron-right" viewBox="0 0 24 24"><path d="M9 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
@@ -36,10 +37,10 @@
         <span class="wordmark">Midnight <strong style="color:var(--accent)">Spell</strong> — Practice</span>
       </div>
       <div class="nav-actions">
-        <div class="cluster" role="group" aria-label="Tema">
-          <button class="btn btn-secondary themeBtn" data-theme="dark" aria-pressed="true">Dark</button>
-          <button class="btn btn-secondary themeBtn" data-theme="light" aria-pressed="false">Light</button>
-          <button class="btn btn-secondary themeBtn" data-theme="hc" aria-pressed="false">HC</button>
+        <div class="theme-selector" role="group" aria-label="Tema">
+          <button class="themeBtn" data-theme="dark" aria-pressed="true" aria-label="Tema scuro"></button>
+          <button class="themeBtn" data-theme="light" aria-pressed="false" aria-label="Tema chiaro"></button>
+          <button class="themeBtn" data-theme="hc" aria-pressed="false" aria-label="Tema alto contrasto"></button>
         </div>
         <div class="cluster" role="search">
           <input id="globalSearch" class="input" style="min-width:220px" placeholder="Cerca effetti… ( / )" aria-label="Cerca" />
@@ -59,7 +60,7 @@
       <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Catalogo</a>
       <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
       <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
-      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Practice</a>
+      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
       <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
     </nav>
   </aside>

--- a/routine/index.html
+++ b/routine/index.html
@@ -21,6 +21,7 @@
   <symbol id="ic-book" viewBox="0 0 24 24"><path d="M4 4h12a3 3 0 0 1 3 3v13H7a3 3 0 0 1-3-3V4z" fill="none" stroke="currentColor" stroke-width="2"/></symbol>
   <symbol id="ic-list" viewBox="0 0 24 24"><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
   <symbol id="ic-theatre" viewBox="0 0 24 24"><path d="M9 3c3 0 6 2 6 5v7c0 3-3 5-6 5S3 18 3 15V8c0-3 3-5 6-5zm12 2c-2 0-4 1-5 3v7c1 2 3 3 5 3s4-1 4-3V8c0-2-2-3-4-3z" fill="none" stroke="currentColor" stroke-width="2"/></symbol>
+  <symbol id="ic-practice" viewBox="0 0 24 24"><path d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
   <symbol id="ic-gear" viewBox="0 0 24 24"><path d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm7.4-3a7.4 7.4 0 0 0 0-0l2.1-1.2-1.5-2.6-2.4.6a7.4 7.4 0 0 0-1.6-.9l-.4-2.5h-3l-.4 2.5a7.4 7.4 0 0 0 1.6.9l-2.4.6-1.5 2.6 2.1 1.2a7.4 7.4 0 0 0 0 0l-2.1 1.2 1.5 2.6 2.4-.6a7.4 7.4 0 0 0 1.6.9l.4 2.5h3l.4-2.5a7.4 7.4 0 0 0 1.6-.9l2.4.6 1.5-2.6-2.1-1.2z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
   <symbol id="ic-plus" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
   <symbol id="ic-chevron-right" viewBox="0 0 24 24"><path d="M9 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
@@ -36,10 +37,10 @@
         <span class="wordmark">Midnight <strong style="color:var(--accent)">Spell</strong> — Routine</span>
       </div>
       <div class="nav-actions">
-        <div class="cluster" role="group" aria-label="Tema">
-          <button class="btn btn-secondary themeBtn" data-theme="dark" aria-pressed="true">Dark</button>
-          <button class="btn btn-secondary themeBtn" data-theme="light" aria-pressed="false">Light</button>
-          <button class="btn btn-secondary themeBtn" data-theme="hc" aria-pressed="false">HC</button>
+        <div class="theme-selector" role="group" aria-label="Tema">
+          <button class="themeBtn" data-theme="dark" aria-pressed="true" aria-label="Tema scuro"></button>
+          <button class="themeBtn" data-theme="light" aria-pressed="false" aria-label="Tema chiaro"></button>
+          <button class="themeBtn" data-theme="hc" aria-pressed="false" aria-label="Tema alto contrasto"></button>
         </div>
         <div class="cluster" role="search">
           <input id="globalSearch" class="input" style="min-width:220px" placeholder="Cerca effetti… ( / )" aria-label="Cerca" />
@@ -59,7 +60,7 @@
       <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Catalogo</a>
       <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
       <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
-      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Practice</a>
+      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
       <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
     </nav>
   </aside>
@@ -103,7 +104,7 @@
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
     <a href="../index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
     <a href="../effects/index.html" aria-label="Catalogo"><svg class="icon"><use href="#ic-book"/></svg><small>Catalogo</small></a>
-    <a href="../routine/index.html" aria-label="Routine"><svg class="icon"><use href="#ic-list"/></svg><small>Routine</small></a>
+    <a href="../routine/index.html" aria-label="Routine" aria-current="page"><svg class="icon"><use href="#ic-list"/></svg><small>Routine</small></a>
     <a href="../show/index.html" aria-label="Show"><svg class="icon"><use href="#ic-theatre"/></svg><small>Show</small></a>
     <a href="../settings/index.html" aria-label="Impostazioni"><svg class="icon"><use href="#ic-gear"/></svg><small>Impost.</small></a>
   </nav>

--- a/settings/index.html
+++ b/settings/index.html
@@ -21,6 +21,7 @@
   <symbol id="ic-book" viewBox="0 0 24 24"><path d="M4 4h12a3 3 0 0 1 3 3v13H7a3 3 0 0 1-3-3V4z" fill="none" stroke="currentColor" stroke-width="2"/></symbol>
   <symbol id="ic-list" viewBox="0 0 24 24"><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
   <symbol id="ic-theatre" viewBox="0 0 24 24"><path d="M9 3c3 0 6 2 6 5v7c0 3-3 5-6 5S3 18 3 15V8c0-3 3-5 6-5zm12 2c-2 0-4 1-5 3v7c1 2 3 3 5 3s4-1 4-3V8c0-2-2-3-4-3z" fill="none" stroke="currentColor" stroke-width="2"/></symbol>
+  <symbol id="ic-practice" viewBox="0 0 24 24"><path d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
   <symbol id="ic-gear" viewBox="0 0 24 24"><path d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm7.4-3a7.4 7.4 0 0 0 0-0l2.1-1.2-1.5-2.6-2.4.6a7.4 7.4 0 0 0-1.6-.9l-.4-2.5h-3l-.4 2.5a7.4 7.4 0 0 0 1.6.9l-2.4.6-1.5 2.6 2.1 1.2a7.4 7.4 0 0 0 0 0l-2.1 1.2 1.5 2.6 2.4-.6a7.4 7.4 0 0 0 1.6.9l.4 2.5h3l.4-2.5a7.4 7.4 0 0 0 1.6-.9l2.4.6 1.5-2.6-2.1-1.2z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
   <symbol id="ic-plus" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
   <symbol id="ic-chevron-right" viewBox="0 0 24 24"><path d="M9 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
@@ -59,7 +60,7 @@
       <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Catalogo</a>
       <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
       <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
-      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Practice</a>
+      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
       <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
     </nav>
   </aside>
@@ -201,7 +202,7 @@
     <a href="../effects/index.html" aria-label="Catalogo"><svg class="icon"><use href="#ic-book"/></svg><small>Catalogo</small></a>
     <a href="../routine/index.html" aria-label="Routine"><svg class="icon"><use href="#ic-list"/></svg><small>Routine</small></a>
     <a href="../show/index.html" aria-label="Show"><svg class="icon"><use href="#ic-theatre"/></svg><small>Show</small></a>
-    <a href="../settings/index.html" aria-label="Impostazioni"><svg class="icon"><use href="#ic-gear"/></svg><small>Impost.</small></a>
+    <a href="../settings/index.html" aria-label="Impostazioni" aria-current="page"><svg class="icon"><use href="#ic-gear"/></svg><small>Impost.</small></a>
   </nav>
 
   <script type="module" src="../assets/js/core/utils.js"></script>

--- a/show/index.html
+++ b/show/index.html
@@ -21,6 +21,7 @@
   <symbol id="ic-book" viewBox="0 0 24 24"><path d="M4 4h12a3 3 0 0 1 3 3v13H7a3 3 0 0 1-3-3V4z" fill="none" stroke="currentColor" stroke-width="2"/></symbol>
   <symbol id="ic-list" viewBox="0 0 24 24"><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
   <symbol id="ic-theatre" viewBox="0 0 24 24"><path d="M9 3c3 0 6 2 6 5v7c0 3-3 5-6 5S3 18 3 15V8c0-3 3-5 6-5zm12 2c-2 0-4 1-5 3v7c1 2 3 3 5 3s4-1 4-3V8c0-2-2-3-4-3z" fill="none" stroke="currentColor" stroke-width="2"/></symbol>
+  <symbol id="ic-practice" viewBox="0 0 24 24"><path d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
   <symbol id="ic-gear" viewBox="0 0 24 24"><path d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm7.4-3a7.4 7.4 0 0 0 0-0l2.1-1.2-1.5-2.6-2.4.6a7.4 7.4 0 0 0-1.6-.9l-.4-2.5h-3l-.4 2.5a7.4 7.4 0 0 0 1.6.9l-2.4.6-1.5 2.6 2.1 1.2a7.4 7.4 0 0 0 0 0l-2.1 1.2 1.5 2.6 2.4-.6a7.4 7.4 0 0 0 1.6.9l.4 2.5h3l.4-2.5a7.4 7.4 0 0 0 1.6-.9l2.4.6 1.5-2.6-2.1-1.2z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
   <symbol id="ic-plus" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
   <symbol id="ic-chevron-right" viewBox="0 0 24 24"><path d="M9 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
@@ -59,7 +60,7 @@
       <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Catalogo</a>
       <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
       <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
-      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Practice</a>
+      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
       <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
     </nav>
   </aside>
@@ -172,7 +173,7 @@
     <a href="../index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
     <a href="../effects/index.html" aria-label="Catalogo"><svg class="icon"><use href="#ic-book"/></svg><small>Catalogo</small></a>
     <a href="../routine/index.html" aria-label="Routine"><svg class="icon"><use href="#ic-list"/></svg><small>Routine</small></a>
-    <a href="../show/index.html" aria-label="Show"><svg class="icon"><use href="#ic-theatre"/></svg><small>Show</small></a>
+    <a href="../show/index.html" aria-label="Show" aria-current="page"><svg class="icon"><use href="#ic-theatre"/></svg><small>Show</small></a>
     <a href="../settings/index.html" aria-label="Impostazioni"><svg class="icon"><use href="#ic-gear"/></svg><small>Impost.</small></a>
   </nav>
 


### PR DESCRIPTION
## Summary
- enlarge global icon size for better alignment
- add distinct practice icon and mark active nav links
- replace textual theme buttons with compact selectors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a37467e94883228719703ad29e8952