### PR TITLE
Allinea layout navbar su tutte le pagine

### DIFF
--- a/effects/add.html
+++ b/effects/add.html
@@ -50,7 +50,8 @@
     </div>
   </div>
 
-  <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
+  <div class="layout">
+    <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
     <div class="cluster" style="justify-content:space-between">
       <strong>Menu</strong>
       <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
@@ -63,8 +64,8 @@
       <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
       <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
     </nav>
-  </aside>
-  <main id="contenuto" class="wrap">
+    </aside>
+    <main id="contenuto" class="wrap">
     
 <section class="stack">
   <article class="surface stack">
@@ -83,7 +84,8 @@
   </article>
 </section>
 
-  </main>
+    </main>
+  </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
     <a href="../index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>

--- a/effects/details.html
+++ b/effects/details.html
@@ -50,7 +50,8 @@
     </div>
   </div>
 
-  <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
+  <div class="layout">
+    <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
     <div class="cluster" style="justify-content:space-between">
       <strong>Menu</strong>
       <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
@@ -63,8 +64,8 @@
       <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
       <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
     </nav>
-  </aside>
-  <main id="contenuto" class="wrap">
+    </aside>
+    <main id="contenuto" class="wrap">
     
 <section class="stack">
   <article class="surface stack">
@@ -136,7 +137,8 @@
   </article>
 </section>
 
-  </main>
+    </main>
+  </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
     <a href="../index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>

--- a/effects/index.html
+++ b/effects/index.html
@@ -50,7 +50,8 @@
     </div>
   </div>
 
-  <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
+  <div class="layout">
+    <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
     <div class="cluster" style="justify-content:space-between">
       <strong>Menu</strong>
       <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
@@ -63,8 +64,8 @@
       <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
       <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
     </nav>
-  </aside>
-  <main id="contenuto" class="wrap">
+    </aside>
+    <main id="contenuto" class="wrap">
     
 <section class="stack">
   <header class="surface stack">
@@ -120,7 +121,8 @@
   <div id="fxList" class="auto-grid" aria-live="polite"></div>
 </section>
 
-  </main>
+    </main>
+  </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
     <a href="../index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>

--- a/practice/index.html
+++ b/practice/index.html
@@ -50,7 +50,8 @@
     </div>
   </div>
 
-  <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
+  <div class="layout">
+    <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
     <div class="cluster" style="justify-content:space-between">
       <strong>Menu</strong>
       <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
@@ -63,8 +64,8 @@
       <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
       <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
     </nav>
-  </aside>
-  <main id="contenuto" class="wrap">
+    </aside>
+    <main id="contenuto" class="wrap">
     
 <section class="stack">
   <article class="surface stack">
@@ -83,7 +84,8 @@
   </article>
 </section>
 
-  </main>
+    </main>
+  </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
     <a href="../index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>

--- a/routine/index.html
+++ b/routine/index.html
@@ -50,7 +50,8 @@
     </div>
   </div>
 
-  <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
+  <div class="layout">
+    <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
     <div class="cluster" style="justify-content:space-between">
       <strong>Menu</strong>
       <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
@@ -63,8 +64,8 @@
       <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
       <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
     </nav>
-  </aside>
-  <main id="contenuto" class="wrap">
+    </aside>
+    <main id="contenuto" class="wrap">
     
 <section class="stack">
   <article class="surface stack">
@@ -99,7 +100,8 @@
   </article>
 </section>
 
-  </main>
+    </main>
+  </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
     <a href="../index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>

--- a/settings/index.html
+++ b/settings/index.html
@@ -50,7 +50,8 @@
     </div>
   </div>
 
-  <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
+  <div class="layout">
+    <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
     <div class="cluster" style="justify-content:space-between">
       <strong>Menu</strong>
       <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
@@ -63,8 +64,8 @@
       <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
       <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
     </nav>
-  </aside>
-  <main id="contenuto" class="wrap">
+    </aside>
+    <main id="contenuto" class="wrap">
     
 <section class="stack">
   <header class="surface">
@@ -195,7 +196,8 @@
   </div>
 </section>
 
-  </main>
+    </main>
+  </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
     <a href="../index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>

--- a/show/index.html
+++ b/show/index.html
@@ -50,7 +50,8 @@
     </div>
   </div>
 
-  <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
+  <div class="layout">
+    <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
     <div class="cluster" style="justify-content:space-between">
       <strong>Menu</strong>
       <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
@@ -63,8 +64,8 @@
       <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
       <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
     </nav>
-  </aside>
-  <main id="contenuto" class="wrap">
+    </aside>
+    <main id="contenuto" class="wrap">
     
 <section class="stack">
   <header class="surface">
@@ -167,7 +168,8 @@
   </div>
 </section>
 
-  </main>
+    </main>
+  </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
     <a href="../index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>


### PR DESCRIPTION
## Summary
- uniforma la navigazione inserendo il wrapper `.layout` attorno a `aside` e `main` in tutte le pagine

## Testing
- `npm test` *(fallisce: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a377bf7bcc8322b035077f5ebd0a82