### PR TITLE
Populate default effects and fix catalog script path

### DIFF
--- a/assets/js/core/state.js
+++ b/assets/js/core/state.js
@@ -5,7 +5,10 @@ const defaultState = {
   effects: [
     {id:'e1',title:'Arcane Key',cat:'Close-up',duration:160,diff:2,summary:'Una chiave apre un lucchetto scelto.',method:'Uso di una chiave gimmick con switch coperto.',materials:['chiave gimmick','lucchetto'],script:'Mostra la chiave antica…',media:[]},
     {id:'e2',title:'Celestial Sphere',cat:'Parlour',duration:210,diff:3,summary:'Un globo rivela costellazioni scelte.',method:'Forzatura + rivelazione luminosa.',materials:['sfera luminosa','telo nero'],script:'Parla di stelle e destino…',media:[]},
-    {id:'e3',title:'Mind Echo',cat:'Mental',duration:180,diff:4,summary:'Indovini un pensiero con eco mentale.',method:'Dual reality + center tear.',materials:['bloc notes','penna'],script:'Chiedi di visualizzare…',media:[]}
+    {id:'e3',title:'Mind Echo',cat:'Mental',duration:180,diff:4,summary:'Indovini un pensiero con eco mentale.',method:'Dual reality + center tear.',materials:['bloc notes','penna'],script:'Chiedi di visualizzare…',media:[]},
+    {id:'e4',title:'Phantom Coin',cat:'Close-up',duration:90,diff:1,summary:'Una moneta attraversa un bicchiere solido.',method:'Uso di moneta gimmick e palming nascosto.',materials:['moneta gimmick','bicchiere'],script:'Mostra come la materia diventa eterea…',media:[]},
+    {id:'e5',title:'Mystic Knot',cat:'Parlour',duration:120,diff:2,summary:'Un nodo si scioglie da solo tra le dita dello spettatore.',method:'Nastro preparato con misdirection.',materials:['nastro'],script:'Invita il pubblico a credere nella magia dei nodi…',media:[]},
+    {id:'e6',title:'Telepathic Link',cat:'Mental',duration:150,diff:3,summary:'Condividi un pensiero con lo spettatore selezionato.',method:'Forzatura mentale e cold reading.',materials:['bloc notes','penna'],script:'Parla di connessioni invisibili della mente…',media:[]}
   ],
   routine: [],
   routineNotes: "",

--- a/effects/index.html
+++ b/effects/index.html
@@ -135,6 +135,6 @@
   <script type="module" src="../assets/js/core/utils.js"></script>
   <script type="module" src="../assets/js/core/state.js"></script>
   <script type="module" src="../assets/js/core/ui.js"></script>
-  <script type="module" src="effects/list.js"></script>
+  <script type="module" src="list.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add several sample magic effects to the default state so the catalog is pre-populated
- Correct the catalog page script reference to load the effect list properly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a37c6645988322bddc15ab7eb5f4ff