### PR TITLE
Gestione impostazioni e show tramite file JSON

### DIFF
--- a/assets/js/core/state.js
+++ b/assets/js/core/state.js
@@ -1,28 +1,40 @@
 const LS_KEY = "spellbook.state.v4";
-const defaultState = {
-  theme: (localStorage.getItem('ms.theme')||'dark'),
-  protect: (localStorage.getItem('ms.protect')||'on'),
-  effects: [
-    {id:'e1',title:'Arcane Key',cat:'Close-up',duration:160,diff:2,summary:'Una chiave apre un lucchetto scelto.',method:'Uso di una chiave gimmick con switch coperto.',materials:['chiave gimmick','lucchetto'],script:'Mostra la chiave antica…',media:[]},
-    {id:'e2',title:'Celestial Sphere',cat:'Parlour',duration:210,diff:3,summary:'Un globo rivela costellazioni scelte.',method:'Forzatura + rivelazione luminosa.',materials:['sfera luminosa','telo nero'],script:'Parla di stelle e destino…',media:[]},
-    {id:'e3',title:'Mind Echo',cat:'Mental',duration:180,diff:4,summary:'Indovini un pensiero con eco mentale.',method:'Dual reality + center tear.',materials:['bloc notes','penna'],script:'Chiedi di visualizzare…',media:[]},
-    {id:'e4',title:'Phantom Coin',cat:'Close-up',duration:90,diff:1,summary:'Una moneta attraversa un bicchiere solido.',method:'Uso di moneta gimmick e palming nascosto.',materials:['moneta gimmick','bicchiere'],script:'Mostra come la materia diventa eterea…',media:[]},
-    {id:'e5',title:'Mystic Knot',cat:'Parlour',duration:120,diff:2,summary:'Un nodo si scioglie da solo tra le dita dello spettatore.',method:'Nastro preparato con misdirection.',materials:['nastro'],script:'Invita il pubblico a credere nella magia dei nodi…',media:[]},
-    {id:'e6',title:'Telepathic Link',cat:'Mental',duration:150,diff:3,summary:'Condividi un pensiero con lo spettatore selezionato.',method:'Forzatura mentale e cold reading.',materials:['bloc notes','penna'],script:'Parla di connessioni invisibili della mente…',media:[]}
-  ],
-  routine: [],
-  routineNotes: "",
-  events:[
-    {date: new Date().toISOString().slice(0,10), title:'Cena aziendale – Milano'},
-    {date: new Date(Date.now()+86400000*3).toISOString().slice(0,10), title:'Wedding – Parma'}
-  ]
-};
-let state = null;
-try{ state = JSON.parse(localStorage.getItem(LS_KEY)) || defaultState; }catch{ state = defaultState; }
-export function getState(){ return state }
-export function saveState(){ localStorage.setItem(LS_KEY, JSON.stringify(state)) }
-export function setTheme(t){ document.documentElement.setAttribute('data-theme', t); localStorage.setItem('ms.theme', t); state.theme = t; saveState() }
-export function setProtect(p){ localStorage.setItem('ms.protect', p); state.protect = p; saveState() }
-export function overwriteEffects(effects){ state.effects = effects; saveState() }
-export function overwriteRoutine(items){ state.routine = items; saveState() }
+
+let defaultState;
+try {
+  const res = await fetch("../../../data/default-state.json");
+  defaultState = await res.json();
+} catch (e) {
+  defaultState = {
+    theme: "dark",
+    protect: "on",
+    effects: [],
+    routine: [],
+    routineNotes: "",
+    events: []
+  };
+}
+
+let state;
+try {
+  state = JSON.parse(localStorage.getItem(LS_KEY)) || defaultState;
+} catch {
+  state = defaultState;
+}
+
+export function getState() { return state; }
+export function saveState() { localStorage.setItem(LS_KEY, JSON.stringify(state)); }
+export function setTheme(t) {
+  document.documentElement.setAttribute('data-theme', t);
+  localStorage.setItem('ms.theme', t);
+  state.theme = t;
+  saveState();
+}
+export function setProtect(p) {
+  localStorage.setItem('ms.protect', p);
+  state.protect = p;
+  saveState();
+}
+export function overwriteEffects(effects) { state.effects = effects; saveState(); }
+export function overwriteRoutine(items) { state.routine = items; saveState(); }
 export default { getState, saveState, setTheme, setProtect, overwriteEffects, overwriteRoutine };

--- a/data/default-state.json
+++ b/data/default-state.json
@@ -1,0 +1,18 @@
+{
+  "theme": "dark",
+  "protect": "on",
+  "effects": [
+    {"id":"e1","title":"Arcane Key","cat":"Close-up","duration":160,"diff":2,"summary":"Una chiave apre un lucchetto scelto.","method":"Uso di una chiave gimmick con switch coperto.","materials":["chiave gimmick","lucchetto"],"script":"Mostra la chiave antica…","media":[]},
+    {"id":"e2","title":"Celestial Sphere","cat":"Parlour","duration":210,"diff":3,"summary":"Un globo rivela costellazioni scelte.","method":"Forzatura + rivelazione luminosa.","materials":["sfera luminosa","telo nero"],"script":"Parla di stelle e destino…","media":[]},
+    {"id":"e3","title":"Mind Echo","cat":"Mental","duration":180,"diff":4,"summary":"Indovini un pensiero con eco mentale.","method":"Dual reality + center tear.","materials":["bloc notes","penna"],"script":"Chiedi di visualizzare…","media":[]},
+    {"id":"e4","title":"Phantom Coin","cat":"Close-up","duration":90,"diff":1,"summary":"Una moneta attraversa un bicchiere solido.","method":"Uso di moneta gimmick e palming nascosto.","materials":["moneta gimmick","bicchiere"],"script":"Mostra come la materia diventa eterea…","media":[]},
+    {"id":"e5","title":"Mystic Knot","cat":"Parlour","duration":120,"diff":2,"summary":"Un nodo si scioglie da solo tra le dita dello spettatore.","method":"Nastro preparato con misdirection.","materials":["nastro"],"script":"Invita il pubblico a credere nella magia dei nodi…","media":[]},
+    {"id":"e6","title":"Telepathic Link","cat":"Mental","duration":150,"diff":3,"summary":"Condividi un pensiero con lo spettatore selezionato.","method":"Forzatura mentale e cold reading.","materials":["bloc notes","penna"],"script":"Parla di connessioni invisibili della mente…","media":[]}
+  ],
+  "routine": [],
+  "routineNotes": "",
+  "events": [
+    {"date": "2024-06-01", "title": "Cena aziendale – Milano"},
+    {"date": "2024-06-04", "title": "Wedding – Parma"}
+  ]
+}

--- a/settings/index.html
+++ b/settings/index.html
@@ -190,6 +190,18 @@
       <small class="meta">Scegli quali sezioni mostrare nella home.</small>
     </article>
 
+    <!-- Sezione Show -->
+    <article class="surface stack">
+      <h3 class="h3">Show</h3>
+
+      <div class="field">
+        <label class="label" for="toggleShowMarkers">Segna i tuoi show</label>
+        <input type="checkbox" id="toggleShowMarkers">
+      </div>
+
+      <small class="meta">Permetti di contrassegnare gli show come completati.</small>
+    </article>
+
     <!-- Sezione Info -->
     <article class="surface stack">
       <h3 class="h3">Informazioni</h3>
@@ -215,6 +227,7 @@
     <div class="cluster" style="justify-content:space-between">
       <h3 class="h3">Dati e Reset</h3>
       <div class="cluster">
+        <button id="btnSaveSettings" class="btn btn-primary">Salva</button>
         <button id="btnResetSettings" class="btn btn-secondary">Reset impostazioni</button>
         <button id="btnResetAll" class="btn btn-secondary">Reset completo app</button>
       </div>

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -90,6 +90,16 @@ sectionToggles.forEach(({ id, key }) => {
   });
 });
 
+// Show markers
+const showMarkersToggle = $("toggleShowMarkers");
+if (showMarkersToggle) {
+  const stored = localStorage.getItem('ms.showMarkers');
+  showMarkersToggle.checked = stored !== 'off';
+  showMarkersToggle.addEventListener('change', () => {
+    localStorage.setItem('ms.showMarkers', showMarkersToggle.checked ? 'on' : 'off');
+  });
+}
+
 // Backup dati
 $("btnBackupData")?.addEventListener("click", () => {
   const allData = {
@@ -104,6 +114,26 @@ $("btnBackupData")?.addEventListener("click", () => {
   };
   
   downloadJSON("spellbook-backup.json", allData);
+});
+
+// Salva impostazioni
+$("btnSaveSettings")?.addEventListener("click", () => {
+  const settings = {
+    theme: themeSelect.value,
+    protect: protectSelect.value,
+    fontSize: fontSizeRange.value,
+    offline: offlineModeSelect.value,
+    notifications: notificationsSelect.value,
+    scriptProtection: scriptProtectionSelect.value,
+    showMarkers: showMarkersToggle?.checked ? 'on' : 'off',
+    sections: {
+      upcoming: $("toggleUpcoming")?.checked,
+      recent: $("toggleRecent")?.checked,
+      stats: $("toggleStats")?.checked,
+      history: $("toggleHistory")?.checked
+    }
+  };
+  downloadJSON("settings.json", settings);
 });
 
 // Importazione dati

--- a/show/show.js
+++ b/show/show.js
@@ -15,6 +15,8 @@ let effectStartTimes = [];
 let totalRoutineDuration = 0;
 let playingState = false;
 const modal = $("showModal");
+const showMarkersEnabled = localStorage.getItem('ms.showMarkers') !== 'off';
+const showStatus = JSON.parse(localStorage.getItem('ms.showStatus') || '{}');
 
 // Carica i dati della routine
 function loadRoutine() {
@@ -69,7 +71,7 @@ function loadRoutine() {
   routine.forEach((item, i) => {
     const effect = state.effects.find(e => e.id === item.id);
     if (!effect) return;
-    
+
     const el = document.createElement("div");
     el.className = "setlist-item surface-2";
     el.dataset.index = i;
@@ -79,6 +81,7 @@ function loadRoutine() {
     el.style.cursor = "pointer";
     el.style.transition = "background 0.2s ease";
     
+    const markHTML = showMarkersEnabled ? `<label class="meta" style="display:flex;align-items:center;gap:4px"><input type="checkbox" class="show-mark"> Fatto</label>` : "";
     el.innerHTML = `
       <div class="cluster" style="justify-content:space-between">
         <div>
@@ -88,9 +91,26 @@ function loadRoutine() {
         <div style="display:flex;flex-direction:column;align-items:flex-end;gap:4px">
           <span class="chip" data-start-at>${fmtSec(effectStartTimes[i])}</span>
           <button class="btn btn-secondary btn-sm" style="padding:4px 10px;min-height:32px">Vai</button>
+          ${markHTML}
         </div>
       </div>
     `;
+
+    if (showMarkersEnabled) {
+      const checkbox = el.querySelector('.show-mark');
+      checkbox.checked = !!showStatus[item.id];
+      if (showStatus[item.id]) el.style.opacity = '0.6';
+      checkbox.addEventListener('change', () => {
+        if (checkbox.checked) {
+          showStatus[item.id] = true;
+          el.style.opacity = '0.6';
+        } else {
+          delete showStatus[item.id];
+          el.style.opacity = '1';
+        }
+        localStorage.setItem('ms.showStatus', JSON.stringify(showStatus));
+      });
+    }
     
     // Aggiungi evento click
     el.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- Caricamento dello stato iniziale da `data/default-state.json` per centralizzare preferenze ed effetti.
- Aggiunta sezione **Show** nelle impostazioni con toggle dedicato e pulsante "Salva" per esportare le preferenze.
- Possibilità di segnare gli effetti della setlist come completati in Show Mode, con salvataggio locale.

## Testing
- `npm test` *(fallito: package.json mancante)*

------
https://chatgpt.com/codex/tasks/task_e_68a3909ae0f0832288cf9ecb29439b39