### PR TITLE
Improve mobile slider and color picker display

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -129,8 +129,15 @@ p,li,code,pre{font-size:var(--f-b)} small{font-size:var(--f-cap);color:var(--mut
 .theme-selector button[data-theme="dark"]::after{background:linear-gradient(135deg, #1C1E3A 50%, #0B0B0D 50%)}
 .theme-selector button[data-theme="light"]::after{background:linear-gradient(135deg, #FFFFFF 50%, #F6F3EC 50%)}
 .theme-selector button[data-theme="hc"]::after{background:linear-gradient(135deg, #000 50%, #FFF 50%);box-shadow:inset 0 0 0 2px #000}
-.color-option{width:36px;height:36px;border-radius:50%;border:2px solid transparent;padding:0;cursor:pointer}
+.color-option{width:36px;height:36px;border-radius:50%;border:2px solid transparent;padding:0;cursor:pointer;-webkit-appearance:none;appearance:none}
 .color-option[aria-pressed="true"]{border-color:var(--text);box-shadow:0 0 0 2px var(--surface-2)}
+
+/* Range sliders */
+input[type="range"]{width:100%;-webkit-appearance:none;appearance:none;background:transparent;border:none;padding:0;margin:0;height:32px;min-height:32px}
+input[type="range"]::-webkit-slider-runnable-track{height:4px;border-radius:2px;background:var(--border)}
+input[type="range"]::-moz-range-track{height:4px;border-radius:2px;background:var(--border)}
+input[type="range"]::-webkit-slider-thumb{-webkit-appearance:none;width:20px;height:20px;border-radius:50%;background:var(--accent);border:2px solid var(--surface-2);cursor:pointer;margin-top:-8px}
+input[type="range"]::-moz-range-thumb{width:20px;height:20px;border-radius:50%;background:var(--accent);border:2px solid var(--surface-2);cursor:pointer}
 @media (max-width: 480px){
   .theme-selector button, .color-option{width:36px;height:36px}
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "server.js",
   "license": "MIT",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test"
   },
   "dependencies": {
     "express": "^4.18.2"

--- a/server.js
+++ b/server.js
@@ -48,6 +48,11 @@ app.delete('/api/effects/:id', async (req, res) => {
 });
 
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`Server listening on port ${PORT}`);
-});
+
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { once } from 'node:events';
+import app from '../server.js';
+
+test('GET /api/effects returns JSON array', async () => {
+  const server = http.createServer(app);
+  server.listen(0);
+  await once(server, 'listening');
+  const port = server.address().port;
+  const res = await fetch(`http://localhost:${port}/api/effects`);
+  assert.equal(res.status, 200);
+  const data = await res.json();
+  assert.ok(Array.isArray(data));
+  server.close();
+});


### PR DESCRIPTION
## Summary
- ensure accent color buttons render reliably on mobile
- restyle range input for the text size slider with custom track and thumb
- export express app and add a basic API test so `npm test` runs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a44f28eb608322b47ade3c5702edab