### PR TITLE
Fix automatic theme selection

### DIFF
--- a/assets/js/core/state.js
+++ b/assets/js/core/state.js
@@ -33,8 +33,22 @@ try {
 
 export function getState() { return state; }
 export function saveState() { localStorage.setItem(LS_KEY, JSON.stringify(state)); }
+let systemThemeMql;
+function applySystemTheme(e){
+  document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light');
+}
 export function setTheme(t) {
-  document.documentElement.setAttribute('data-theme', t);
+  if(systemThemeMql){
+    systemThemeMql.removeEventListener('change', applySystemTheme);
+    systemThemeMql = null;
+  }
+  if(t === 'auto'){
+    systemThemeMql = window.matchMedia('(prefers-color-scheme: dark)');
+    applySystemTheme(systemThemeMql);
+    systemThemeMql.addEventListener('change', applySystemTheme);
+  } else {
+    document.documentElement.setAttribute('data-theme', t);
+  }
   localStorage.setItem('ms.theme', t);
   state.theme = t;
   saveState();

--- a/assets/js/core/ui.js
+++ b/assets/js/core/ui.js
@@ -1,6 +1,11 @@
 import { qsa, qs, trapFocus } from "./utils.js";
 import { getState, setTheme } from "./state.js";
-document.documentElement.setAttribute("data-theme", getState().theme);
+setTheme(getState().theme);
+function updateThemeButtons(){
+  const current = document.documentElement.getAttribute('data-theme');
+  qsa('.themeBtn').forEach(b=> b.setAttribute('aria-pressed', b.dataset.theme === current ? 'true' : 'false'));
+}
+updateThemeButtons();
 // Drawer + focus trap
 const drawer = qs("#drawer"); const openD = qs("#openDrawer"); const closeD = qs("#closeDrawer"); let untrap=null;
 if(openD && drawer && closeD){
@@ -28,7 +33,7 @@ if(drawer){
 qsa(".themeBtn").forEach(btn=>{
   btn.addEventListener("click", ()=>{
     setTheme(btn.dataset.theme);
-    qsa('.themeBtn').forEach(b=> b.setAttribute('aria-pressed', String(b===btn)));
+    updateThemeButtons();
     const sel = qs("#setTheme"); if(sel) sel.value = btn.dataset.theme;
   });
 });

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -11,10 +11,11 @@ const themeSelect = $("setTheme");
 themeSelect.value = getState().theme;
 themeSelect.addEventListener("change", () => {
   setTheme(themeSelect.value);
-  
+
   // Aggiorna i pulsanti del tema
+  const current = document.documentElement.getAttribute('data-theme');
   document.querySelectorAll('.themeBtn').forEach(btn => {
-    btn.setAttribute('aria-pressed', btn.dataset.theme === themeSelect.value ? 'true' : 'false');
+    btn.setAttribute('aria-pressed', btn.dataset.theme === current ? 'true' : 'false');
   });
 });
 


### PR DESCRIPTION
## Summary
- add automatic theme mode following system preference
- update UI theme buttons to reflect current theme

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a451926f248322a13698e438079a9e