### PR TITLE
fix: persist accent color selection

### DIFF
--- a/assets/js/core/ui.js
+++ b/assets/js/core/ui.js
@@ -1,7 +1,21 @@
 import { qsa, qs, trapFocus } from "./utils.js";
 import { getState, setTheme } from "./state.js";
 import { initReveal } from "./reveal.js";
+
 setTheme(getState().theme);
+
+// Initialize accent color from localStorage
+const storedAccent = localStorage.getItem('ms.accent');
+if (storedAccent) {
+  document.documentElement.style.setProperty('--accent', storedAccent);
+}
+
+// Export helper to change accent color
+export function setAccentColor(color) {
+  document.documentElement.style.setProperty('--accent', color);
+  localStorage.setItem('ms.accent', color);
+}
+
 function updateThemeButtons(){
   const current = document.documentElement.getAttribute('data-theme');
   qsa('.themeBtn').forEach(b=> b.setAttribute('aria-pressed', b.dataset.theme === current ? 'true' : 'false'));

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -1,5 +1,6 @@
 import { initGlobalSearch } from "../assets/js/core/search-ui.js";
 import { getState, setProtect, setTheme } from "../assets/js/core/state.js";
+import { setAccentColor } from "../assets/js/core/ui.js";
 import { $, downloadJSON, importJSON, onKeySlashFocus, wireActiveNav } from "../assets/js/core/utils.js";
 
 wireActiveNav();
@@ -227,12 +228,6 @@ function calculateStorageUsage() {
 // Applica dimensione del testo
 function applyFontSize(value) {
   document.documentElement.style.setProperty('--fontSize-scale', `${value}%`);
-}
-
-// Imposta colore principale
-function setAccentColor(color) {
-  document.documentElement.style.setProperty('--accent', color);
-  localStorage.setItem('ms.accent', color);
 }
 
 // Inizializza colore accent


### PR DESCRIPTION
## Summary
- load stored accent color on every page and expose helper to update it
- use shared helper in settings to persist user color choice

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4567b932883229d7ca46c7a189b09