### PR TITLE
Fix home navigation and service worker caching

### DIFF
--- a/effects/add.html
+++ b/effects/add.html
@@ -58,7 +58,7 @@
       <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
     </div>
     <nav class="stack" style="margin-top:12px">
-      <a class="btn btn-ghost" href="../index.html"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
+      <a class="btn btn-ghost" href="../"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
       <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Effetti</a>
       <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
       <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
@@ -89,7 +89,7 @@
   </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
-    <a href="../index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
+    <a href="../" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
     <a href="../effects/index.html" aria-label="Effetti" aria-current="page"><svg class="icon"><use href="#ic-book"/></svg><small>Effetti</small></a>
     <a href="../routine/index.html" aria-label="Routine"><svg class="icon"><use href="#ic-list"/></svg><small>Routine</small></a>
     <a href="../show/index.html" aria-label="Show"><svg class="icon"><use href="#ic-theatre"/></svg><small>Show</small></a>

--- a/effects/details.html
+++ b/effects/details.html
@@ -58,7 +58,7 @@
       <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
     </div>
     <nav class="stack" style="margin-top:12px">
-      <a class="btn btn-ghost" href="../index.html"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
+      <a class="btn btn-ghost" href="../"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
       <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Effetti</a>
       <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
       <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
@@ -142,7 +142,7 @@
   </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
-    <a href="../index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
+    <a href="../" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
     <a href="../effects/index.html" aria-label="Effetti" aria-current="page"><svg class="icon"><use href="#ic-book"/></svg><small>Effetti</small></a>
     <a href="../routine/index.html" aria-label="Routine"><svg class="icon"><use href="#ic-list"/></svg><small>Routine</small></a>
     <a href="../show/index.html" aria-label="Show"><svg class="icon"><use href="#ic-theatre"/></svg><small>Show</small></a>

--- a/effects/index.html
+++ b/effects/index.html
@@ -58,7 +58,7 @@
       <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
     </div>
     <nav class="stack" style="margin-top:12px">
-      <a class="btn btn-ghost" href="../index.html"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
+      <a class="btn btn-ghost" href="../"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
       <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Effetti</a>
       <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
       <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
@@ -126,7 +126,7 @@
   </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
-    <a href="../index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
+    <a href="../" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
     <a href="../effects/index.html" aria-label="Effetti" aria-current="page"><svg class="icon"><use href="#ic-book"/></svg><small>Effetti</small></a>
     <a href="../routine/index.html" aria-label="Routine"><svg class="icon"><use href="#ic-list"/></svg><small>Routine</small></a>
     <a href="../show/index.html" aria-label="Show"><svg class="icon"><use href="#ic-theatre"/></svg><small>Show</small></a>

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
         <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
       </div>
       <nav class="stack" style="margin-top:12px">
-        <a class="btn btn-ghost" href="index.html"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
+        <a class="btn btn-ghost" href="/"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
         <a class="btn btn-ghost" href="effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Effetti</a>
         <a class="btn btn-ghost" href="routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
         <a class="btn btn-ghost" href="show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
@@ -155,7 +155,7 @@
   </div>
 
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
-    <a href="index.html" aria-label="Home" aria-current="page"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
+    <a href="/" aria-label="Home" aria-current="page"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
     <a href="effects/index.html" aria-label="Effetti"><svg class="icon"><use href="#ic-book"/></svg><small>Effetti</small></a>
     <a href="routine/index.html" aria-label="Routine"><svg class="icon"><use href="#ic-list"/></svg><small>Routine</small></a>
     <a href="show/index.html" aria-label="Show"><svg class="icon"><use href="#ic-theatre"/></svg><small>Show</small></a>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Midnight Spellbook",
   "short_name": "Spellbook",
-  "start_url": "./index.html",
+  "start_url": "/",
   "display": "standalone",
   "scope": "./",
   "theme_color": "#0B0B0D",
@@ -57,14 +57,14 @@
       "name": "Show Mode",
       "short_name": "Show",
       "description": "Avvia modalità show",
-      "url": "./show/index.html",
+        "url": "/show/index.html",
       "icons": [{ "src": "./assets/img/favicon.svg", "sizes": "192x192" }]
     },
     {
       "name": "Effetti",
       "short_name": "Effetti",
       "description": "Visualizza gli effetti",
-      "url": "./effects/index.html",
+        "url": "/effects/index.html",
       "icons": [{ "src": "./assets/img/favicon.svg", "sizes": "192x192" }]
     }
   ]

--- a/offline.html
+++ b/offline.html
@@ -23,13 +23,13 @@
       <p>Verifica la connessione internet e riprova.</p>
       <div class="cluster" style="justify-content:center;margin-top:24px">
         <button class="btn btn-primary" onclick="window.location.reload()">Riprova</button>
-        <a href="index.html" class="btn btn-secondary">Torna alla Home</a>
+        <a href="/" class="btn btn-secondary">Torna alla Home</a>
       </div>
       
       <div style="margin-top:40px">
         <h3 class="h3">Contenuti disponibili offline:</h3>
         <nav class="stack" style="max-width:300px;margin:0 auto">
-          <a class="btn btn-secondary" href="index.html">Home</a>
+          <a class="btn btn-secondary" href="/">Home</a>
           <a class="btn btn-secondary" href="effects/index.html">Effetti</a>
           <a class="btn btn-secondary" href="routine/index.html">Routine</a>
           <a class="btn btn-secondary" href="settings/index.html">Impostazioni</a>

--- a/practice/index.html
+++ b/practice/index.html
@@ -58,7 +58,7 @@
       <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
     </div>
     <nav class="stack" style="margin-top:12px">
-      <a class="btn btn-ghost" href="../index.html"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
+      <a class="btn btn-ghost" href="../"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
       <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Effetti</a>
       <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
       <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
@@ -89,7 +89,7 @@
   </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
-    <a href="../index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
+    <a href="../" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
     <a href="../effects/index.html" aria-label="Effetti"><svg class="icon"><use href="#ic-book"/></svg><small>Effetti</small></a>
     <a href="../routine/index.html" aria-label="Routine"><svg class="icon"><use href="#ic-list"/></svg><small>Routine</small></a>
     <a href="../show/index.html" aria-label="Show"><svg class="icon"><use href="#ic-theatre"/></svg><small>Show</small></a>

--- a/routine/index.html
+++ b/routine/index.html
@@ -58,7 +58,7 @@
       <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
     </div>
     <nav class="stack" style="margin-top:12px">
-      <a class="btn btn-ghost" href="../index.html"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
+      <a class="btn btn-ghost" href="../"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
       <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Effetti</a>
       <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
       <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
@@ -105,7 +105,7 @@
   </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
-    <a href="../index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
+    <a href="../" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
     <a href="../effects/index.html" aria-label="Effetti"><svg class="icon"><use href="#ic-book"/></svg><small>Effetti</small></a>
     <a href="../routine/index.html" aria-label="Routine" aria-current="page"><svg class="icon"><use href="#ic-list"/></svg><small>Routine</small></a>
     <a href="../show/index.html" aria-label="Show"><svg class="icon"><use href="#ic-theatre"/></svg><small>Show</small></a>

--- a/settings/index.html
+++ b/settings/index.html
@@ -58,7 +58,7 @@
       <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
     </div>
     <nav class="stack" style="margin-top:12px">
-      <a class="btn btn-ghost" href="../index.html"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
+      <a class="btn btn-ghost" href="../"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
       <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Effetti</a>
       <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
       <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
@@ -241,7 +241,7 @@
   </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
-    <a href="../index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
+    <a href="../" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
     <a href="../effects/index.html" aria-label="Effetti"><svg class="icon"><use href="#ic-book"/></svg><small>Effetti</small></a>
     <a href="../routine/index.html" aria-label="Routine"><svg class="icon"><use href="#ic-list"/></svg><small>Routine</small></a>
     <a href="../show/index.html" aria-label="Show"><svg class="icon"><use href="#ic-theatre"/></svg><small>Show</small></a>

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -209,7 +209,7 @@ $("btnResetAll")?.addEventListener("click", () => {
     }
     
     alert('Tutti i dati sono stati cancellati. L\'app verrà riavviata.');
-    setTimeout(() => location.href = '../index.html', 500);
+    setTimeout(() => location.href = '../', 500);
   }
 });
 

--- a/show/index.html
+++ b/show/index.html
@@ -58,7 +58,7 @@
       <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
     </div>
     <nav class="stack" style="margin-top:12px">
-      <a class="btn btn-ghost" href="../index.html"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
+      <a class="btn btn-ghost" href="../"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
       <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Effetti</a>
       <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
       <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
@@ -173,7 +173,7 @@
   </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
-    <a href="../index.html" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
+    <a href="../" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>
     <a href="../effects/index.html" aria-label="Effetti"><svg class="icon"><use href="#ic-book"/></svg><small>Effetti</small></a>
     <a href="../routine/index.html" aria-label="Routine"><svg class="icon"><use href="#ic-list"/></svg><small>Routine</small></a>
     <a href="../show/index.html" aria-label="Show" aria-current="page"><svg class="icon"><use href="#ic-theatre"/></svg><small>Show</small></a>

--- a/sw.js
+++ b/sw.js
@@ -4,23 +4,32 @@ const DYNAMIC_CACHE = 'spellbook-dynamic-v1.0';
 
 // Risorse statiche da precaricare
 const STATIC_ASSETS = [
-  './',
-  './index.html',
-  './manifest.json',
-  './assets/css/tokens.css',
-  './assets/css/base.css',
-  './assets/js/core/utils.js',
-  './assets/js/core/state.js',
-  './assets/js/core/ui.js',
-  './assets/js/core/search.js',
-  './assets/js/core/search-ui.js',
-  './home.js',
-  './effects/index.html','./effects/list.js','./effects/details.html','./effects/details.js','./effects/add.html','./effects/add.js',
-  './routine/index.html','./routine/routine.js',
-  './show/index.html','./show/show.js',
-  './practice/index.html','./practice/practice.js',
-  './settings/index.html','./settings/settings.js',
-  './assets/img/favicon.svg'
+  '/',
+  '/index.html',
+  '/manifest.json',
+  '/assets/css/tokens.css',
+  '/assets/css/base.css',
+  '/assets/js/core/utils.js',
+  '/assets/js/core/state.js',
+  '/assets/js/core/ui.js',
+  '/assets/js/core/search.js',
+  '/assets/js/core/search-ui.js',
+  '/home.js',
+  '/effects/index.html',
+  '/effects/list.js',
+  '/effects/details.html',
+  '/effects/details.js',
+  '/effects/add.html',
+  '/effects/add.js',
+  '/routine/index.html',
+  '/routine/routine.js',
+  '/show/index.html',
+  '/show/show.js',
+  '/practice/index.html',
+  '/practice/practice.js',
+  '/settings/index.html',
+  '/settings/settings.js',
+  '/assets/img/favicon.svg'
 ];
 
 // Pagine di fallback
@@ -40,7 +49,7 @@ const FALLBACK_HTML = `
       <h1>Offline</h1>
       <p>Sei offline e questa pagina non è disponibile nella cache.</p>
       <p>Verifica la connessione e riprova.</p>
-      <a href="./index.html" class="btn btn-primary">Torna alla home</a>
+      <a href="/" class="btn btn-primary">Torna alla home</a>
     </div>
   </main>
 </body>
@@ -97,8 +106,7 @@ self.addEventListener('fetch', event => {
   const requestUrl = new URL(request.url);
   
   // Strategia: Cache con fallback alla rete per le risorse statiche
-  if (STATIC_ASSETS.some(asset => 
-      requestUrl.pathname.endsWith(asset) || asset === requestUrl.pathname)) {
+  if (STATIC_ASSETS.includes(requestUrl.pathname)) {
     event.respondWith(
       caches.match(request)
         .then(cachedResponse => {


### PR DESCRIPTION
## Summary
- Point all Home navigation links to the site root so the same page is loaded everywhere
- Replace relative static asset paths with absolute ones and simplify service worker caching logic
- Set manifest start_url and shortcuts to root-based paths and update offline fallback/redirects

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a459a0bd248322898dec81c729287c