### PR TITLE
Fix theme reset when navigating pages

### DIFF
--- a/assets/js/core/ui.js
+++ b/assets/js/core/ui.js
@@ -2,7 +2,8 @@ import { qsa, qs, trapFocus } from "./utils.js";
 import { getState, setTheme } from "./state.js";
 import { initReveal } from "./reveal.js";
 
-setTheme(getState().theme);
+const storedTheme = localStorage.getItem('ms.theme') || getState().theme;
+setTheme(storedTheme);
 
 // Initialize accent color from localStorage
 const storedAccent = localStorage.getItem('ms.accent');

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -9,7 +9,7 @@ initGlobalSearch();
 
 // Gestione tema
 const themeSelect = $("setTheme");
-themeSelect.value = getState().theme;
+themeSelect.value = localStorage.getItem('ms.theme') || getState().theme;
 themeSelect.addEventListener("change", () => {
   setTheme(themeSelect.value);
 


### PR DESCRIPTION
## Summary
- Load saved theme from localStorage when initializing UI
- Ensure Settings page reads the stored theme value

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a45b6e559c83229cda3fc803ed8c71