### PR TITLE
Remove mobile burger menu and fix theme color updating

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -23,11 +23,10 @@ p,li,code,pre{font-size:var(--f-b)} small{font-size:var(--f-cap);color:var(--mut
 .brand .wordmark{font-weight:800;letter-spacing:.5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .nav-actions{display:flex;gap:8px;align-items:center}
 .burger{display:none}
-@media (max-width: 768px){ 
-  .nav-actions{display:none} 
-  .burger{display:inline-flex}
+@media (max-width: 768px){
+  .nav-actions{display:none}
   .topbar-inner{padding:8px max(12px,2vw)}
-  .brand .wordmark{max-width:min(70vw,240px)} 
+  .brand .wordmark{max-width:min(70vw,240px)}
 }
 /* Drawer */
 .drawer{position:fixed;inset:0 0 0 auto;width:min(360px,92vw);transform:translateX(100%);transition:transform var(--dur-drawer) var(--ease);background:var(--surface);border-left:1px solid var(--border);box-shadow:var(--e4);padding:20px;z-index:30;overflow-y:auto;padding-bottom:calc(20px + var(--safe-b) + 70px)}

--- a/assets/js/core/state.js
+++ b/assets/js/core/state.js
@@ -39,8 +39,16 @@ fetchEffects();
 export function getState() { return state; }
 export function saveState() { localStorage.setItem(LS_KEY, JSON.stringify(state)); }
 let systemThemeMql;
+function updateMetaTheme(){
+  const meta = document.querySelector('meta[name="theme-color"]');
+  if(meta){
+    const color = getComputedStyle(document.documentElement).getPropertyValue('--bg').trim();
+    meta.setAttribute('content', color);
+  }
+}
 function applySystemTheme(e){
   document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light');
+  updateMetaTheme();
 }
 export function setTheme(t) {
   if(systemThemeMql){
@@ -53,6 +61,7 @@ export function setTheme(t) {
     systemThemeMql.addEventListener('change', applySystemTheme);
   } else {
     document.documentElement.setAttribute('data-theme', t);
+    updateMetaTheme();
   }
   localStorage.setItem('ms.theme', t);
   state.theme = t;


### PR DESCRIPTION
## Summary
- Hide burger menu in all viewports to remove it from mobile UI
- Update theme switching logic to refresh `<meta name="theme-color">` when themes change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4634bd4a48322a0d0985bb47fd547