### PR TITLE
Remove burger menu and theme toggle duplication

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -22,16 +22,10 @@ p,li,code,pre{font-size:var(--f-b)} small{font-size:var(--f-cap);color:var(--mut
 .brand{display:flex;align-items:center;gap:10px}
 .brand .wordmark{font-weight:800;letter-spacing:.5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .nav-actions{display:flex;gap:8px;align-items:center}
-.burger{display:none}
 @media (max-width: 768px){
-  .nav-actions{display:none}
   .topbar-inner{padding:8px max(12px,2vw)}
   .brand .wordmark{max-width:min(70vw,240px)}
 }
-/* Drawer */
-.drawer{position:fixed;inset:0 0 0 auto;width:min(360px,92vw);transform:translateX(100%);transition:transform var(--dur-drawer) var(--ease);background:var(--surface);border-left:1px solid var(--border);box-shadow:var(--e4);padding:20px;z-index:30;overflow-y:auto;padding-bottom:calc(20px + var(--safe-b) + 70px)}
-.drawer.show{transform:translateX(0)}
-.drawer .btn-ghost{padding:14px 16px}
 /* Bottom nav */
 .bottombar{position:fixed;bottom:0;left:0;right:0;background:var(--surface-2);border-top:1px solid var(--border);display:grid;grid-template-columns:repeat(5,1fr);padding:0;border-radius:20px 20px 0 0;box-shadow:0 -8px 16px rgba(0,0,0,.25);z-index:50}
 .bottombar a{display:flex;flex-direction:column;align-items:center;gap:4px;padding:12px 6px;padding-bottom:calc(12px + var(--safe-b));text-align:center}
@@ -41,14 +35,8 @@ p,li,code,pre{font-size:var(--f-b)} small{font-size:var(--f-cap);color:var(--mut
 @media (max-width:380px){ .bottombar small{font-size:10px} }
 @media (max-width:340px){ .bottombar small{display:none} }
 
-/* Layout + sidebar on desktop */
-.layout{display:block}
 @media (min-width:768px){
-  .layout{display:flex;align-items:flex-start}
-  .layout .drawer{position:sticky;top:0;transform:none;width:260px;border-left:none;border-right:1px solid var(--border);box-shadow:none;height:100vh;padding-bottom:20px}
-  .layout main{flex:1}
   .wrap{padding-bottom:40px}
-  #closeDrawer{display:none}
   .bottombar{display:none}
 }
 /* Buttons */
@@ -173,4 +161,4 @@ mark{background:color-mix(in oklab,var(--accent),transparent 70%);color:inherit;
 .icon{width:24px;height:24px;flex-shrink:0}
 img, svg, video{max-width:100%;height:auto;display:block}
 /* Print */
-@media print{.topbar,.bottombar,.drawer{display:none!important};body{color:#111;background:#fff}}
+@media print{.topbar,.bottombar{display:none!important};body{color:#111;background:#fff}}

--- a/assets/css/tokens.css
+++ b/assets/css/tokens.css
@@ -12,7 +12,7 @@
   --f-cap:calc(12px * var(--fontSize-scale) / 100);
   --r-s:4px; --r-m:8px; --r-l:12px; --r-xl:20px; --r-xxl:28px; --r-pill:999px; --bw-1:1px; --bw-2:1.5px; --bw-3:2px;
   --e1:0 1px 2px -1px rgba(0,0,0,.20); --e2:0 2px 6px -2px rgba(0,0,0,.22); --e3:0 6px 12px -4px rgba(0,0,0,.25); --e4:0 10px 20px -6px rgba(0,0,0,.28);
-  --ease:cubic-bezier(.2,0,0,1); --dur-press:90ms; --dur-hover:150ms; --dur-modal:240ms; --dur-drawer:360ms;
+  --ease:cubic-bezier(.2,0,0,1); --dur-press:90ms; --dur-hover:150ms; --dur-modal:240ms;
   --maxw:1280px; --safe-b:env(safe-area-inset-bottom,0px);
 }
 [data-theme="light"]{ --bg:#F6F3EC; --surface:#FFFFFF; --surface-2:#F2EFE8; --text:#20201E; --muted:#5B5B58; --accent:#7B6330; --border:#14141422; --link:#6B5426; --success:#2E7D5B; --warning:#9A6F1F; --error:#7B1F1A; --info:#35506A; }

--- a/effects/add.html
+++ b/effects/add.html
@@ -34,8 +34,7 @@
   <div class="topbar">
     <div class="topbar-inner">
       <div class="brand">
-        <button class="btn btn-secondary burger" id="openDrawer" aria-label="Apri menu"><svg class="icon"><use href="#ic-bars"/></svg></button>
-        <span class="wordmark">Midnight <strong style="color:var(--accent)">Spell</strong> — Aggiungi Effetto</span>
+                <span class="wordmark">Midnight <strong style="color:var(--accent)">Spell</strong> — Aggiungi Effetto</span>
       </div>
       <div class="nav-actions">
         <div class="theme-selector" role="group" aria-label="Tema">
@@ -50,23 +49,7 @@
       </div>
     </div>
   </div>
-
-  <div class="layout">
-    <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
-    <div class="cluster" style="justify-content:space-between">
-      <strong>Menu</strong>
-      <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
-    </div>
-    <nav class="stack" style="margin-top:12px">
-      <a class="btn btn-ghost" href="../"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
-      <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Effetti</a>
-      <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
-      <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
-      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
-      <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
-    </nav>
-    </aside>
-    <main id="contenuto" class="wrap">
+  <main id="contenuto" class="wrap">
     
 <section class="stack">
   <article class="surface stack">
@@ -84,9 +67,7 @@
     <div class="cluster"><a class="btn btn-secondary" href="index.html">Annulla</a><button id="aeSave" class="btn btn-primary"><svg class="icon"><use href="#ic-plus"/></svg> Aggiungi</button></div>
   </article>
 </section>
-
     </main>
-  </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
     <a href="../" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>

--- a/effects/details.html
+++ b/effects/details.html
@@ -34,8 +34,7 @@
   <div class="topbar">
     <div class="topbar-inner">
       <div class="brand">
-        <button class="btn btn-secondary burger" id="openDrawer" aria-label="Apri menu"><svg class="icon"><use href="#ic-bars"/></svg></button>
-        <span class="wordmark">Midnight <strong style="color:var(--accent)">Spell</strong> — Dettaglio Effetto</span>
+                <span class="wordmark">Midnight <strong style="color:var(--accent)">Spell</strong> — Dettaglio Effetto</span>
       </div>
       <div class="nav-actions">
         <div class="theme-selector" role="group" aria-label="Tema">
@@ -50,23 +49,7 @@
       </div>
     </div>
   </div>
-
-  <div class="layout">
-    <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
-    <div class="cluster" style="justify-content:space-between">
-      <strong>Menu</strong>
-      <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
-    </div>
-    <nav class="stack" style="margin-top:12px">
-      <a class="btn btn-ghost" href="../"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
-      <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Effetti</a>
-      <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
-      <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
-      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
-      <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
-    </nav>
-    </aside>
-    <main id="contenuto" class="wrap">
+  <main id="contenuto" class="wrap">
     
 <section class="stack">
   <article class="surface stack">
@@ -137,9 +120,7 @@
     </div>
   </article>
 </section>
-
     </main>
-  </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
     <a href="../" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>

--- a/effects/index.html
+++ b/effects/index.html
@@ -34,8 +34,7 @@
   <div class="topbar">
     <div class="topbar-inner">
       <div class="brand">
-        <button class="btn btn-secondary burger" id="openDrawer" aria-label="Apri menu"><svg class="icon"><use href="#ic-bars"/></svg></button>
-        <span class="wordmark">Midnight <strong style="color:var(--accent)">Spell</strong> — Effetti</span>
+                <span class="wordmark">Midnight <strong style="color:var(--accent)">Spell</strong> — Effetti</span>
       </div>
       <div class="nav-actions">
         <div class="theme-selector" role="group" aria-label="Tema">
@@ -50,23 +49,7 @@
       </div>
     </div>
   </div>
-
-  <div class="layout">
-    <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
-    <div class="cluster" style="justify-content:space-between">
-      <strong>Menu</strong>
-      <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
-    </div>
-    <nav class="stack" style="margin-top:12px">
-      <a class="btn btn-ghost" href="../"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
-      <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Effetti</a>
-      <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
-      <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
-      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
-      <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
-    </nav>
-    </aside>
-    <main id="contenuto" class="wrap">
+  <main id="contenuto" class="wrap">
     
 <section class="stack">
   <header class="surface stack">
@@ -121,9 +104,7 @@
   </header>
   <div id="fxList" class="auto-grid" aria-live="polite"></div>
 </section>
-
     </main>
-  </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
     <a href="../" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,6 @@
   <div class="topbar">
     <div class="topbar-inner">
       <div class="brand">
-        <button class="btn btn-secondary burger" id="openDrawer" aria-label="Apri menu"><svg class="icon"><use href="#ic-bars"/></svg></button>
         <span class="wordmark">Midnight <strong style="color:var(--accent)">Spell</strong> — Home</span>
       </div>
       <div class="nav-actions">
@@ -50,33 +49,13 @@
   </div>
   </div>
   
-  <div class="layout">
-    <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
-      <div class="cluster" style="justify-content:space-between">
-        <strong>Menu</strong>
-        <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
-      </div>
-      <nav class="stack" style="margin-top:12px">
-        <a class="btn btn-ghost" href="/"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
-        <a class="btn btn-ghost" href="effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Effetti</a>
-        <a class="btn btn-ghost" href="routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
-        <a class="btn btn-ghost" href="show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
-        <a class="btn btn-ghost" href="practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
-        <a class="btn btn-ghost" href="settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
-      </nav>
-    </aside>
-    <main id="contenuto" class="wrap">
+  <main id="contenuto" class="wrap">
     
 <section class="stack">
   <header class="surface stack">
-    <div class="cluster" style="justify-content:space-between;align-items:flex-end">
-      <h1 class="logo">Spellbook</h1>
-      <div class="theme-selector" role="group" aria-label="Tema">
-        <button class="themeBtn" data-theme="dark" aria-pressed="true" aria-label="Tema scuro"></button>
-        <button class="themeBtn" data-theme="light" aria-pressed="false" aria-label="Tema chiaro"></button>
-        <button class="themeBtn" data-theme="hc" aria-pressed="false" aria-label="Tema alto contrasto"></button>
+      <div class="cluster" style="justify-content:space-between;align-items:flex-end">
+        <h1 class="logo">Spellbook</h1>
       </div>
-    </div>
     <p class="meta clamp-2" style="max-width:70ch">Dashboard: avvio rapido show, composer routine, effetti recenti, prossimi eventi.</p>
     <div class="cluster">
       <a class="btn btn-primary" href="show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Avvia Show</a>
@@ -149,10 +128,9 @@
       <ul id="homeUpcoming" class="upcoming-list"></ul>
     </article>
   </div>
-</section>
+  </section>
 
-  </main>
-  </div>
+    </main>
 
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
     <a href="/" aria-label="Home" aria-current="page"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>

--- a/practice/index.html
+++ b/practice/index.html
@@ -34,8 +34,7 @@
   <div class="topbar">
     <div class="topbar-inner">
       <div class="brand">
-        <button class="btn btn-secondary burger" id="openDrawer" aria-label="Apri menu"><svg class="icon"><use href="#ic-bars"/></svg></button>
-        <span class="wordmark">Midnight <strong style="color:var(--accent)">Spell</strong> — Practice</span>
+                <span class="wordmark">Midnight <strong style="color:var(--accent)">Spell</strong> — Practice</span>
       </div>
       <div class="nav-actions">
         <div class="theme-selector" role="group" aria-label="Tema">
@@ -50,23 +49,7 @@
       </div>
     </div>
   </div>
-
-  <div class="layout">
-    <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
-    <div class="cluster" style="justify-content:space-between">
-      <strong>Menu</strong>
-      <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
-    </div>
-    <nav class="stack" style="margin-top:12px">
-      <a class="btn btn-ghost" href="../"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
-      <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Effetti</a>
-      <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
-      <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
-      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
-      <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
-    </nav>
-    </aside>
-    <main id="contenuto" class="wrap">
+  <main id="contenuto" class="wrap">
     
 <section class="stack">
   <article class="surface stack">
@@ -84,9 +67,7 @@
     </div>
   </article>
 </section>
-
     </main>
-  </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
     <a href="../" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>

--- a/routine/index.html
+++ b/routine/index.html
@@ -34,8 +34,7 @@
   <div class="topbar">
     <div class="topbar-inner">
       <div class="brand">
-        <button class="btn btn-secondary burger" id="openDrawer" aria-label="Apri menu"><svg class="icon"><use href="#ic-bars"/></svg></button>
-        <span class="wordmark">Midnight <strong style="color:var(--accent)">Spell</strong> — Routine</span>
+                <span class="wordmark">Midnight <strong style="color:var(--accent)">Spell</strong> — Routine</span>
       </div>
       <div class="nav-actions">
         <div class="theme-selector" role="group" aria-label="Tema">
@@ -50,23 +49,7 @@
       </div>
     </div>
   </div>
-
-  <div class="layout">
-    <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
-    <div class="cluster" style="justify-content:space-between">
-      <strong>Menu</strong>
-      <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
-    </div>
-    <nav class="stack" style="margin-top:12px">
-      <a class="btn btn-ghost" href="../"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
-      <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Effetti</a>
-      <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
-      <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
-      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
-      <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
-    </nav>
-    </aside>
-    <main id="contenuto" class="wrap">
+  <main id="contenuto" class="wrap">
     
 <section class="stack">
   <article class="surface stack">
@@ -100,9 +83,7 @@
     </div>
   </article>
 </section>
-
     </main>
-  </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
     <a href="../" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>

--- a/settings/index.html
+++ b/settings/index.html
@@ -34,8 +34,7 @@
   <div class="topbar">
     <div class="topbar-inner">
       <div class="brand">
-        <button class="btn btn-secondary burger" id="openDrawer" aria-label="Apri menu"><svg class="icon"><use href="#ic-bars"/></svg></button>
-        <span class="wordmark">Midnight <strong style="color:var(--accent)">Spell</strong> — Impostazioni</span>
+                <span class="wordmark">Midnight <strong style="color:var(--accent)">Spell</strong> — Impostazioni</span>
       </div>
       <div class="nav-actions">
         <div class="theme-selector" role="group" aria-label="Tema">
@@ -50,23 +49,7 @@
       </div>
     </div>
   </div>
-
-  <div class="layout">
-    <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
-    <div class="cluster" style="justify-content:space-between">
-      <strong>Menu</strong>
-      <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
-    </div>
-    <nav class="stack" style="margin-top:12px">
-      <a class="btn btn-ghost" href="../"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
-      <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Effetti</a>
-      <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
-      <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
-      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
-      <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
-    </nav>
-    </aside>
-    <main id="contenuto" class="wrap">
+  <main id="contenuto" class="wrap">
     
 <section class="stack">
   <header class="surface">
@@ -236,9 +219,7 @@
     <p class="meta">Il reset completo cancellerà tutti i dati salvati e riporterà l'app allo stato iniziale.</p>
   </div>
 </section>
-
     </main>
-  </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
     <a href="../" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>

--- a/show/index.html
+++ b/show/index.html
@@ -34,8 +34,7 @@
   <div class="topbar">
     <div class="topbar-inner">
       <div class="brand">
-        <button class="btn btn-secondary burger" id="openDrawer" aria-label="Apri menu"><svg class="icon"><use href="#ic-bars"/></svg></button>
-        <span class="wordmark">Midnight <strong style="color:var(--accent)">Spell</strong> — Show Mode</span>
+                <span class="wordmark">Midnight <strong style="color:var(--accent)">Spell</strong> — Show Mode</span>
       </div>
       <div class="nav-actions">
         <div class="theme-selector" role="group" aria-label="Tema">
@@ -50,23 +49,7 @@
       </div>
     </div>
   </div>
-
-  <div class="layout">
-    <aside class="drawer" id="drawer" aria-label="Menu" aria-hidden="true" tabindex="-1">
-    <div class="cluster" style="justify-content:space-between">
-      <strong>Menu</strong>
-      <button class="btn btn-secondary" id="closeDrawer">Chiudi</button>
-    </div>
-    <nav class="stack" style="margin-top:12px">
-      <a class="btn btn-ghost" href="../"><svg class="icon"><use href="#ic-home"/></svg> Home</a>
-      <a class="btn btn-ghost" href="../effects/index.html"><svg class="icon"><use href="#ic-book"/></svg> Effetti</a>
-      <a class="btn btn-ghost" href="../routine/index.html"><svg class="icon"><use href="#ic-list"/></svg> Routine</a>
-      <a class="btn btn-ghost" href="../show/index.html"><svg class="icon"><use href="#ic-theatre"/></svg> Show Mode</a>
-      <a class="btn btn-ghost" href="../practice/index.html"><svg class="icon"><use href="#ic-practice"/></svg> Practice</a>
-      <a class="btn btn-ghost" href="../settings/index.html"><svg class="icon"><use href="#ic-gear"/></svg> Impostazioni</a>
-    </nav>
-    </aside>
-    <main id="contenuto" class="wrap">
+  <main id="contenuto" class="wrap">
     
 <section class="stack">
   <header class="surface">
@@ -168,9 +151,7 @@
     </div>
   </div>
 </section>
-
     </main>
-  </div>
   
   <nav class="bottombar" aria-label="Navigazione principale" id="bottomNav">
     <a href="../" aria-label="Home"><svg class="icon"><use href="#ic-home"/></svg><small>Home</small></a>


### PR DESCRIPTION
## Summary
- Remove unused burger menu and side drawer from all pages
- Show navigation actions on all viewports and drop duplicate theme selector
- Clean up drawer-related CSS variables and styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4af5283688322bc774052964febcd